### PR TITLE
fix #93 match error return and remove unnecessary operation symbols

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,13 +1,9 @@
-block_labels = [ "Rust" ]
-delete_merged_branches = true
-timeout_sec = 2400
-# keep MSRV in sync in ci.yaml, bors.toml, and setup.md
 status = [
-  "Dependency Check",
-  "MacOS Stable",
-  "MacOS Nightly",
-  "Ubuntu Stable",
-  "Ubuntu Nightly",
-  "Windows Stable",
-  "Windows Nightly",
+    '%' # All checks must pass before merging into master
 ]
+delete_merged_branches = true
+use_squash_merge = true
+pr_status = [ 'license/cla' ]
+timeout_sec = 7200
+cut_body_after = "<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->"
+required_approvals = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ members = [
     "mybatis-util",
     "mybatis",
 ]
+
+exclude = [".github/"]

--- a/example/src/connection.rs
+++ b/example/src/connection.rs
@@ -5,16 +5,14 @@ use mybatis::plus::Mapping;
 mod tests {
     use super::*;
 
-    // #[tokio::test]
-    // async fn test_database() {
-    //     let rb = Mybatis::new();
-    //     ///连接数据库,自动判断驱动类型"mysql://*","postgres://*","sqlite://*","mssql://*"加载驱动
-    //     rb.link("mysql://root:passw0rd@localhost:3306/COVID-19").await.unwrap();
-    //     // use crate::core::db::DBPoolOptions;
-    //     // let mut opt =DBPoolOptions::new();
-    //     // opt.max_connections=100;
-    //     // rb.link_opt("mysql://root:123456@localhost:3306/test",&opt).await.unwrap();
-
-    //     //启用日志输出，你也可以使用其他日志框架，这个不限定的
-    // }
+    #[tokio::test]
+    async fn test_database() {
+        // 连接数据库,自动判断驱动类型"mysql://*","postgres://*","sqlite://*","mssql://*"加载驱动
+        // let rb = Mybatis::new();
+        // rb.link("mysql://root:passw0rd@localhost:3306/COVID-19").await.unwrap();
+        // use crate::core::db::DBPoolOptions;
+        // let mut opt =DBPoolOptions::new();
+        // opt.max_connections=100;
+        // rb.link_opt("mysql://root:123456@localhost:3306/test",&opt).await.unwrap();
+    }
 }

--- a/example/src/plugin_page_test.rs
+++ b/example/src/plugin_page_test.rs
@@ -32,6 +32,4 @@ mod tests {
         println!("{}", select);
     }
 
-    #[test]
-    fn test_all() {}
 }

--- a/mybatis-sql/src/ops.rs
+++ b/mybatis-sql/src/ops.rs
@@ -1,10 +1,6 @@
-use std::borrow::{Borrow, Cow};
 use std::cmp::Ordering;
-use std::fmt::{Debug, Formatter};
-use std::ops::{Deref, Index};
 
 use rbson::{Document, Timestamp};
-use serde::{Deserializer, Serializer};
 use std::cmp::Ordering::Less;
 
 /// convert Value to Value

--- a/mybatis-sql/src/ops_div.rs
+++ b/mybatis-sql/src/ops_div.rs
@@ -1,5 +1,4 @@
 use crate::ops::Div;
-use rbson::Bson;
 
 use crate::ops::AsProxy;
 use crate::ops::Value;
@@ -8,14 +7,14 @@ fn op_div_u64(value: &Value, other: u64) -> u64 {
     if other == 0 {
         return 0;
     }
-    (value.u64() / other)
+    value.u64() / other
 }
 
 fn op_div_i64(value: &Value, other: i64) -> i64 {
     if other == 0 {
         return 0;
     }
-    (value.i64() / other)
+    value.i64() / other
 }
 
 fn op_div_f64(value: &Value, other: f64) -> f64 {
@@ -30,7 +29,7 @@ fn op_div_i64_value(value: &Value, other: i64) -> i64 {
     if v == 0 {
         return 0;
     }
-    (other / v)
+    other / v
 }
 
 fn op_div_u64_value(value: &Value, other: u64) -> u64 {
@@ -38,7 +37,7 @@ fn op_div_u64_value(value: &Value, other: u64) -> u64 {
     if v == 0 {
         return 0;
     }
-    (other / v)
+    other / v
 }
 
 fn op_div_f64_value(value: &Value, other: f64) -> f64 {
@@ -46,7 +45,7 @@ fn op_div_f64_value(value: &Value, other: f64) -> f64 {
     if v == 0.0 {
         return 0.0;
     }
-    (other / v)
+    other / v
 }
 
 macro_rules! impl_numeric_div {
@@ -128,7 +127,7 @@ impl_numeric_div! {
 impl Div<&Value> for Value {
     type Output = Value;
     fn op_div(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {
@@ -174,7 +173,7 @@ impl Div<&Value> for Value {
 impl Div<&&Value> for Value {
     type Output = Value;
     fn op_div(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {
@@ -220,7 +219,7 @@ impl Div<&&Value> for Value {
 impl Div<Value> for Value {
     type Output = Value;
     fn op_div(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {
@@ -266,7 +265,7 @@ impl Div<Value> for Value {
 impl Div<Value> for &Value {
     type Output = Value;
     fn op_div(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {
@@ -312,7 +311,7 @@ impl Div<Value> for &Value {
 impl Div<&Value> for &Value {
     type Output = Value;
     fn op_div(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {
@@ -358,7 +357,7 @@ impl Div<&Value> for &Value {
 impl Div<&&Value> for &Value {
     type Output = Value;
     fn op_div(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
                 if rhs == 0.0 {

--- a/mybatis-sql/src/ops_index.rs
+++ b/mybatis-sql/src/ops_index.rs
@@ -1,6 +1,5 @@
 use crate::ops::{OpsIndex, OpsIndexMut, Value};
 use rbson::Document;
-use std::ops;
 
 pub trait Index: private::Sealed {
     /// Return None if the key is not already in the array or object.

--- a/mybatis-sql/src/ops_mul.rs
+++ b/mybatis-sql/src/ops_mul.rs
@@ -5,7 +5,7 @@ use crate::ops::Value;
 impl Mul<&Value> for Value {
     type Output = Value;
     fn op_mul(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);
@@ -36,7 +36,7 @@ impl Mul<&Value> for Value {
 impl Mul<&&Value> for Value {
     type Output = Value;
     fn op_mul(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);
@@ -67,7 +67,7 @@ impl Mul<&&Value> for Value {
 impl Mul<Value> for Value {
     type Output = Value;
     fn op_mul(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);
@@ -98,7 +98,7 @@ impl Mul<Value> for Value {
 impl Mul<&Value> for &Value {
     type Output = Value;
     fn op_mul(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);
@@ -129,7 +129,7 @@ impl Mul<&Value> for &Value {
 impl Mul<&&Value> for &Value {
     type Output = Value;
     fn op_mul(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);
@@ -160,7 +160,7 @@ impl Mul<&&Value> for &Value {
 impl Mul<Value> for &Value {
     type Output = Value;
     fn op_mul(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s * rhs);

--- a/mybatis-sql/src/ops_rem.rs
+++ b/mybatis-sql/src/ops_rem.rs
@@ -6,7 +6,7 @@ use crate::ops::Value;
 impl Rem<Value> for Value {
     type Output = Value;
     fn op_rem(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);
@@ -37,7 +37,7 @@ impl Rem<Value> for Value {
 impl Rem<&Value> for Value {
     type Output = Value;
     fn op_rem(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);
@@ -68,7 +68,7 @@ impl Rem<&Value> for Value {
 impl Rem<&&Value> for Value {
     type Output = Value;
     fn op_rem(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);
@@ -99,7 +99,7 @@ impl Rem<&&Value> for Value {
 impl Rem<Value> for &Value {
     type Output = Value;
     fn op_rem(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);
@@ -130,7 +130,7 @@ impl Rem<Value> for &Value {
 impl Rem<&Value> for &Value {
     type Output = Value;
     fn op_rem(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);
@@ -161,7 +161,7 @@ impl Rem<&Value> for &Value {
 impl Rem<&&Value> for &Value {
     type Output = Value;
     fn op_rem(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s % rhs);

--- a/mybatis-sql/src/ops_sub.rs
+++ b/mybatis-sql/src/ops_sub.rs
@@ -6,7 +6,7 @@ use crate::ops::Value;
 impl Sub<&Value> for Value {
     type Output = Value;
     fn op_sub(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -17,11 +17,11 @@ impl Sub<&Value> for Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
@@ -37,7 +37,7 @@ impl Sub<&Value> for Value {
 impl Sub<&&Value> for Value {
     type Output = Value;
     fn op_sub(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -48,11 +48,11 @@ impl Sub<&&Value> for Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
@@ -68,7 +68,7 @@ impl Sub<&&Value> for Value {
 impl Sub<Value> for Value {
     type Output = Value;
     fn op_sub(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -79,11 +79,11 @@ impl Sub<Value> for Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
@@ -99,7 +99,7 @@ impl Sub<Value> for Value {
 impl Sub<&Value> for &Value {
     type Output = Value;
     fn op_sub(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -110,11 +110,11 @@ impl Sub<&Value> for &Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
@@ -130,7 +130,7 @@ impl Sub<&Value> for &Value {
 impl Sub<&&Value> for &Value {
     type Output = Value;
     fn op_sub(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -141,11 +141,11 @@ impl Sub<&&Value> for &Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();
@@ -161,7 +161,7 @@ impl Sub<&&Value> for &Value {
 impl Sub<Value> for &Value {
     type Output = Value;
     fn op_sub(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int64((s - rhs) as i64);
@@ -172,11 +172,11 @@ impl Sub<Value> for &Value {
             }
             Value::UInt32(s) => {
                 let rhs = rhs.u32();
-                return Value::UInt64(((s - rhs) as u64));
+                return Value::UInt64((s - rhs) as u64);
             }
             Value::UInt64(s) => {
                 let rhs = rhs.u64();
-                return Value::UInt64((s - rhs));
+                return Value::UInt64(s - rhs);
             }
             Value::Double(s) => {
                 let rhs = rhs.as_f64().unwrap_or_default();

--- a/mybatis-sql/src/ops_xor.rs
+++ b/mybatis-sql/src/ops_xor.rs
@@ -6,7 +6,7 @@ use crate::ops::Value;
 impl BitXor<&Value> for Value {
     type Output = Value;
     fn op_bitxor(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);
@@ -37,7 +37,7 @@ impl BitXor<&Value> for Value {
 impl BitXor<&&Value> for Value {
     type Output = Value;
     fn op_bitxor(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);
@@ -68,7 +68,7 @@ impl BitXor<&&Value> for Value {
 impl BitXor<Value> for Value {
     type Output = Value;
     fn op_bitxor(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);
@@ -99,7 +99,7 @@ impl BitXor<Value> for Value {
 impl BitXor<&Value> for &Value {
     type Output = Value;
     fn op_bitxor(self, rhs: &Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);
@@ -130,7 +130,7 @@ impl BitXor<&Value> for &Value {
 impl BitXor<&&Value> for &Value {
     type Output = Value;
     fn op_bitxor(self, rhs: &&Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);
@@ -161,7 +161,7 @@ impl BitXor<&&Value> for &Value {
 impl BitXor<Value> for &Value {
     type Output = Value;
     fn op_bitxor(self, rhs: Value) -> Self::Output {
-        return match self {
+        match self {
             Value::Int32(s) => {
                 let rhs = rhs.i32();
                 return Value::Int32(s ^ rhs);

--- a/mybatis-sql/src/template.rs
+++ b/mybatis-sql/src/template.rs
@@ -1,5 +1,4 @@
 use once_cell::sync::Lazy;
-use std::convert::identity;
 
 pub static TEMPLATE: Lazy<SqlTemplates> = Lazy::new(|| SqlTemplates::default());
 

--- a/mybatis/src/plus.rs
+++ b/mybatis/src/plus.rs
@@ -18,11 +18,9 @@ use crate::page::{IPage, IPageRequest, Page};
 use crate::wrapper::Wrapper;
 
 use mybatis_sql::ops::AsProxy;
-use mybatis_sql::rule::SqlRule;
 use mybatis_sql::TEMPLATE;
 use mybatis_util::string_util::{self, to_snake_name};
 use rbson::Bson;
-use rbson::Bson::Null;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::option::Option::Some;


### PR DESCRIPTION
1. fix error :
```
any code following this `match` expression is unreachable, as all arms diverge
```

2. remove unnecessary operation symbols